### PR TITLE
Catch keyerror for failed queries

### DIFF
--- a/analyzer/extract.py
+++ b/analyzer/extract.py
@@ -135,35 +135,38 @@ def summary(j: dict):
         fragments = list(iter_plans(stage))
         substages = build_tasks_in_substages(stage)
 
-    return dict(
-        query=j["query"],
-        query_id=j["queryId"],
-        user=session["user"],
-        state=j["state"],
-        error_code=j.get("errorCode"),
-        update=j.get("updateType"),
-        elapsed_time=parse_time(stats["elapsedTime"]),
-        cpu_time=parse_time(stats["totalCpuTime"]),
-        scheduled_time=parse_time(stats["totalScheduledTime"]),
-        blocked_time=parse_time(stats["totalBlockedTime"]),
-        input_size=(
-                parse_size(stats["rawInputDataSize"])
-                or parse_size(stats.get("inputDataSize"))
-                or 0
-        ),
-        output_size=parse_size(stats["outputDataSize"]),
-        network_size=parse_size(stats.get("internalNetworkInputDataSize")),
-        input_rows=stats["rawInputPositions"],
-        output_rows=stats["outputPositions"],
-        network_rows=stats.get("internalNetworkInputPositions"),
-        peak_mem=parse_size(stats["peakTotalMemoryReservation"]),
-        written_size=parse_size(stats.get("rawWrittenDataSize")),
-        operators=list(get_operators(stats["operatorSummaries"])),
-        inputs=j["inputs"],
-        output=j.get("output"),
-        fragments=fragments,
-        substages=substages
-    )
+    try:
+        return dict(
+            query=j["query"],
+            query_id=j["queryId"],
+            user=session["user"],
+            state=j["state"],
+            error_code=j.get("errorCode"),
+            update=j.get("updateType"),
+            elapsed_time=parse_time(stats["elapsedTime"]),
+            cpu_time=parse_time(stats["totalCpuTime"]),
+            scheduled_time=parse_time(stats["totalScheduledTime"]),
+            blocked_time=parse_time(stats["totalBlockedTime"]),
+            input_size=(
+                    parse_size(stats["rawInputDataSize"])
+                    or parse_size(stats.get("inputDataSize"))
+                    or 0
+            ),
+            output_size=parse_size(stats["outputDataSize"]),
+            network_size=parse_size(stats.get("internalNetworkInputDataSize")),
+            input_rows=stats["rawInputPositions"],
+            output_rows=stats["outputPositions"],
+            network_rows=stats.get("internalNetworkInputPositions"),
+            peak_mem=parse_size(stats["peakTotalMemoryReservation"]),
+            written_size=parse_size(stats.get("rawWrittenDataSize")),
+            operators=list(get_operators(stats["operatorSummaries"])),
+            inputs=j["inputs"],
+            output=j.get("output"),
+            fragments=fragments,
+            substages=substages
+        )
+    except KeyError:
+        log.warning("missing key for {}", stats)
 
 
 def main():


### PR DESCRIPTION
Currently any collection of queries which includes failures (ie. USER_ERROR) on Presto 0.261 will cause it to fail with a KeyError: 

`./extract.py -i ./JSONs/ && ./analyze.py -i ./JSONs/summary.jsonl.gz -o ./output.zip                                                                                                                                                                                                                                             21:49:58
[2022-04-29 02:50:22.202612] INFO: extract: 719 JSONs found at ~/presto-workload-analyzer/analyzer/JSONs
 34%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉                                                                                                                                                                                                                               | 647k/1.88M [00:00<00:00, 2.16MB/s]
Traceback (most recent call last):
  File "~/presto-workload-analyzer/analyzer/./extract.py", line 211, in <module>
    main()
  File "~/presto-workload-analyzer/analyzer/./extract.py", line 196, in main
    s = summary(json.load(f))
  File "~/presto-workload-analyzer/analyzer/./extract.py", line 148, in summary
    blocked_time=parse_time(stats["totalBlockedTime"]),
KeyError: 'totalBlockedTime'`



This PR catches this, passing on it and simply prints a warning message.